### PR TITLE
follow deep relationships

### DIFF
--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -73,3 +73,21 @@ class User(Base):
         yield "is_active", self.is_active
         yield "active", self.active
         yield "address", self.address
+
+
+class Blog(Base):
+    __tablename__ = 'blog'
+    id = sa.Column(sa.Integer, primary_key=True)
+    title = sa.Column(sa.Text)
+    user_id = sa.Column(sa.Integer, sa.ForeignKey('user.user_id'))
+
+    user = relationship('User', backref='blogs')
+
+
+class Post(Base):
+    __tablename__ = 'post'
+    id = sa.Column(sa.Integer, primary_key=True)
+    title = sa.Column(sa.Text)
+    blog_id = sa.Column(sa.Integer, sa.ForeignKey('blog.id'))
+
+    blog = relationship('Blog', backref='posts')

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -2,7 +2,7 @@ import pytest
 from sqlalchemy import func
 from sqlalchemy import not_
 
-from fixtures import User
+from fixtures import User, Blog, Post
 from rqlalchemy import RQLQueryError
 
 
@@ -200,4 +200,31 @@ class TestQuery:
         )
 
         assert res
+        assert res == exp
+
+    def test_like_with_relationship_1_deep(self, session, blogs):
+        res = (
+            session.query(User)
+            .rql('like((blogs, title), *1*)')
+            .rql_all()
+        )
+        exp = (
+            session.query(User).join(Blog)
+            .filter(Blog.title.like('%1%'))
+            .all()
+        )
+        assert res == exp
+
+
+    def test_like_with_relationship_2_deep(self, session, posts):
+        res = (
+            session.query(User)
+            .rql('like((blogs, posts, title), *Post 1*)')
+            .rql_all()
+        )
+        exp = (
+            session.query(User).join(Blog).join(Post)
+            .filter(Post.title.like('%Post 1%'))
+            .all()
+        )
         assert res == exp


### PR DESCRIPTION
Following relationships to attributes was allowed using tuples, but only 1 relationship deep (by limiting the tuple to length 2). For example:

`like((blogs, title), *frogs*)`

would work, but

`like((blogs, posts, title), *amazonian frogs*)`

would not.

This pull request adds the ability to go arbitrarily deep with the above syntax (so the second example would work). Tests and extra fixtures for a 2-deep relationship are also added.